### PR TITLE
Fix timestamp file commit permissions

### DIFF
--- a/.github/workflows/ping-supabase.yml
+++ b/.github/workflows/ping-supabase.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   check-and-ping:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to commit and push timestamp updates
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,7 +69,12 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           
-          # Commit the updated timestamp
+          # Commit and push the updated timestamp
           git add .github/last-ping-timestamp
-          git commit -m "Update last ping timestamp [automated]" || exit 0
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update last ping timestamp [automated]"
+            git push
+            echo "✅ Timestamp updated successfully"
+          fi


### PR DESCRIPTION
Add `contents: write` permission and improve timestamp update logic to fix the daily ping bug.

The workflow was failing to update the `.github/last-ping-timestamp` file due to missing `contents: write` permissions. The `git commit || exit 0` command masked this failure, causing subsequent runs to incorrectly assume no previous execution and run daily instead of every 3 days. This PR adds the necessary permissions and improves error handling to ensure the timestamp is correctly updated.